### PR TITLE
fix global issue with Capabilities

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.14.1
+version: 0.14.2
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -22,7 +22,7 @@ spec:
 ...
 {{- range .Values.backup.jobs }}
 ---
-{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
 {{- else -}}
 apiVersion: batch/v1beta1


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Fix for Capabilities issue that I introduced (sorry about that)

#### Special notes for your reviewer
was broken here https://github.com/timescale/helm-charts/pull/426

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
timescaledb-single:
- (root): Additional property global is not allowed
```

it does not need global scope 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] [CLA signed](https://cla-assistant.io/timescale/helm-charts)
